### PR TITLE
refactoring: remove argparse in favor of pydantic-settings and subprocess

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.gitlab-ci.yml
+.mypy_cache
+.pytest_cache
+.pre-commit-config.yaml
+.venv
+hooks
+junit.xml
+coverage.xml
+docker
+docs

--- a/README.md
+++ b/README.md
@@ -250,13 +250,68 @@ Please check [docs/CHECKPOINTS.md](docs/CHECKPOINTS.md) to download all the mode
 ## 🔆 Get started
 
 ### 1.Prepare environment
+
+Install Poetry: https://python-poetry.org/docs/#installation
+
+On Linux only
+
 ``` shell
-conda create -n videotuna python=3.10 -y
-conda activate videotuna
-pip install poetry
+poetry config virtualenvs.in-project true # optional but recommended, will ensure the virtual env is created in the project root
+poetry env use python3.10 # will create the virtual env, check with `ls -l .venv`.
+poetry env activate # optional because Poetry commands (e.g. `poetry install` or `poetry run <command>`) will always automatically load the virtual env.
 poetry install
-poetry run pip install "modelscope[cv]" -f https://modelscope.oss-cn-beijing.aliyuncs.com/releases/repo.html
 ```
+
+On MacOS with Apple Silicon chip use [docker compose](https://docs.docker.com/compose/) because some dependencies are not supporting arm64 (e.g. `bitsandbytes`, `decord`, `xformers`).
+
+First build:
+
+```shell
+docker compose build videotuna
+```
+
+To preserve the project's files permissions set those env variables:
+
+```shell
+export HOST_UID=$(id -u)
+export HOST_GID=$(id -g)
+```
+
+Install dependencies:
+
+```shell
+docker compose run --remove-orphans videotuna poetry env use /usr/local/bin/python
+docker compose run --remove-orphans videotuna poetry run python -m pip install --upgrade pip setuptools wheel
+docker compose run --remove-orphans videotuna poetry install
+docker compose run --remove-orphans videotuna poetry run pip install "modelscope[cv]" -f https://modelscope.oss-cn-beijing.aliyuncs.com/releases/repo.html
+```
+
+Note: installing swissarmytransformer might hang. Just try again and it should work.
+
+Add a dependency:
+
+```shell
+docker compose run --remove-orphans videotuna poetry add wheel
+```
+
+Check dependencies:
+
+```shell
+docker compose run --remove-orphans videotuna poetry run pip freeze
+```
+
+Run Poetry commands:
+
+```shell
+docker compose run --remove-orphans videotuna poetry run format
+```
+
+Start a terminal:
+
+```shell
+docker compose run -it --remove-orphans videotuna bash
+```
+
 **Flash-attn installation (Optional)**
 
 Hunyuan model uses it to reduce memory usage and speed up inference. If it is not installed, the model will run in normal mode.
@@ -321,21 +376,15 @@ Before started, we assume you have finished the following two preliminary steps:
   ll checkpoints/stablediffusion/v2-1_512-ema/model.ckpt
 ```
 
-
 First, run this command to convert the VC2 checkpoint as we make minor modifications on the keys of the state dict of the checkpoint. The converted checkpoint will be automatically save at `checkpoints/videocrafter/t2v_v2_512/model_converted.ckpt`.    
 ```
 python tools/convert_checkpoint.py --input_path checkpoints/videocrafter/t2v_v2_512/model.ckpt
 ```
 
-
 Second, run this command to start training on the single GPU. The training results will be automatically saved at `results/train/${CURRENT_TIME}_${EXPNAME}`    
 ```
 poetry run train-videocrafter-v2
 ```
-
-
-
-
 
 #### 2. VideoCrafter2 Lora Fine-tuning
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  videotuna:
+    image: "videotuna:${TAG-latest}"
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: docker/poetry/Dockerfile
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"  # Run as the host's user
+    volumes:
+      - .:/opt/VideoTuna

--- a/docker/poetry/Dockerfile
+++ b/docker/poetry/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.10-bookworm
+
+ARG UID=1000
+ARG GID=1000
+
+WORKDIR /opt/VideoTuna/
+
+RUN groupadd -g "${GID}" videotuna \
+    && useradd -m -u "${UID}" -s /usr/bin/bash -g videotuna videotuna \
+    && chown -R videotuna:videotuna /opt/VideoTuna/ \
+    && chmod -R 755 /opt/VideoTuna/ \
+    && pip install pipx
+
+USER videotuna
+
+WORKDIR /opt/VideoTuna/
+
+ENV PATH="/home/videotuna/.local/bin:${PATH}"
+
+RUN pipx ensurepath \
+    && pipx install poetry \
+    && poetry config virtualenvs.in-project true

--- a/poetry.lock
+++ b/poetry.lock
@@ -4925,21 +4925,25 @@ test = ["pytest"]
 
 [[package]]
 name = "setuptools"
-version = "69.5.1"
+version = "75.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"},
-    {file = "setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"},
+    {file = "setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3"},
+    {file = "setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.8.0)"]
+core = ["importlib_metadata (>=6)", "jaraco.collections", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
 name = "six"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3844,6 +3844,28 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.8.0"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "pydantic_settings-2.8.0-py3-none-any.whl", hash = "sha256:c782c7dc3fb40e97b238e713c25d26f64314aece2e91abcff592fcac15f71820"},
+    {file = "pydantic_settings-2.8.0.tar.gz", hash = "sha256:88e2ca28f6e68ea102c99c3c401d6c9078e68a5df600e97b43891c34e089500a"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -3985,6 +4007,22 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytorch-lightning"
@@ -6124,4 +6162,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b86a5f9c1bf9bab40f3c554920f30d8edd1142f8bd558c8843edce18fd20900a"
+content-hash = "b208bf0ec5dcf03f679d7d3e56c587ec3d4796bec12ba3507ae0cfdb8bb63537"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ toml = "0.10.2"
 hpsv2 = {git = "https://github.com/tgxs002/HPSv2.git"}
 backports-tarfile = "^1.2.0"
 swissarmytransformer = {git = "https://github.com/JingyeChen/SwissArmyTransformer"}
+modelscope = {extras = ["cv"], version = "^1.11.1", source = "modelscope"}
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"
@@ -71,6 +72,11 @@ pytest = "7.2.0"
 pre-commit = "^4.0.0"
 coverage = "^7.6.1"
 ruff = "^0.6.8"
+
+[[tool.poetry.source]]
+name = "modelscope"
+url = "https://modelscope.oss-cn-beijing.aliyuncs.com/releases/repo.html"
+priority = "supplemental"
 
 [tool.poetry.scripts]
 install-flash-attn = 'scripts:install_flash_attn'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ toml = "0.10.2"
 hpsv2 = {git = "https://github.com/tgxs002/HPSv2.git"}
 backports-tarfile = "^1.2.0"
 swissarmytransformer = {git = "https://github.com/JingyeChen/SwissArmyTransformer"}
-modelscope = {extras = ["cv"], version = "^1.11.1", source = "modelscope"}
+pydantic-settings = "^2.8.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"
@@ -72,11 +72,6 @@ pytest = "7.2.0"
 pre-commit = "^4.0.0"
 coverage = "^7.6.1"
 ruff = "^0.6.8"
-
-[[tool.poetry.source]]
-name = "modelscope"
-url = "https://modelscope.oss-cn-beijing.aliyuncs.com/releases/repo.html"
-priority = "supplemental"
 
 [tool.poetry.scripts]
 install-flash-attn = 'scripts:install_flash_attn'

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -522,21 +522,13 @@ def inference_opensora_v10_16x256x256():
 
 
 def inference_v2v_ms():
-    input_dir = "inputs/v2v/001"
-    output_dir = f"results/v2v/{current_time}-v2v-modelscope-001"
-    result = subprocess.run(
-        [
-            "python3",
-            "scripts/inference_v2v_ms.py",
-            "--input_dir",
-            input_dir,
-            "--output_dir",
-            output_dir,
-        ]
-        + sys.argv[1:],
-        check=False,
+    from .inference_v2v_ms import Settings, inference_v2v_ms
+
+    settings = Settings(
+        input_dir="inputs/v2v/001",
+        output_dir=f"results/v2v/{current_time}-v2v-modelscope-001",
     )
-    exit(result.returncode)
+    inference_v2v_ms(settings=settings)
 
 
 def inference_vc1_i2v_320x512():

--- a/tools/data_process/caption/llava/model/multimodal_encoder/dev_eva_clip/eva_clip/timm_model.py
+++ b/tools/data_process/caption/llava/model/multimodal_encoder/dev_eva_clip/eva_clip/timm_model.py
@@ -18,9 +18,7 @@ try:
         from timm.models.layers.attention_pool2d import (
             AttentionPool2d as AbsAttentionPool2d,
         )
-        from timm.models.layers.attention_pool2d import (
-            RotAttentionPool2d,
-        )
+        from timm.models.layers.attention_pool2d import RotAttentionPool2d
     except ImportError:
         # new timm imports >= 0.8.1
         from timm.layers import AttentionPool2d as AbsAttentionPool2d

--- a/tools/data_process/caption/llava/train/llava_trainer.py
+++ b/tools/data_process/caption/llava/train/llava_trainer.py
@@ -19,9 +19,7 @@ from transformers.trainer import (
     is_sagemaker_mp_enabled,
     logger,
 )
-from transformers.trainer_pt_utils import (
-    AcceleratorConfig,
-)
+from transformers.trainer_pt_utils import AcceleratorConfig
 from transformers.trainer_pt_utils import (
     get_length_grouped_indices as get_length_grouped_indices_hf,
 )

--- a/videotuna/third_party/flux/models/smoldit/__init__.py
+++ b/videotuna/third_party/flux/models/smoldit/__init__.py
@@ -1,5 +1,5 @@
-from videotuna.third_party.flux.models.smoldit.transformer import SmolDiT2DModel
 from videotuna.third_party.flux.models.smoldit.pipeline import SmolDiTPipeline
+from videotuna.third_party.flux.models.smoldit.transformer import SmolDiT2DModel
 
 SmolDiTConfigurations = {
     "smoldit-small": {


### PR DESCRIPTION
This is my proposal to remove `argparse`, thereby eliminating one level of indirection.

Please note that I deleted `scripts.py` and moved its content to `scripts/__init__.py` because I converted the scripts directory into a Python module.