### PR TITLE
fix: support user-defined random seed to inference flux lora t2i and cogvideo i2v models

### DIFF
--- a/scripts/inference_cogVideo_sat_refactor.py
+++ b/scripts/inference_cogVideo_sat_refactor.py
@@ -254,6 +254,7 @@ def main(args, model_cls):
 
             for index in range(args.batch_size):
                 shape = (T, C, H, W) if args.image2video else (T, C, H // 8, W // 8)
+                set_random_seed(args.seed)
                 samples_z = (
                     sample_func(c, uc=uc, batch_size=1, shape=shape)
                     .permute(0, 2, 1, 3, 4)

--- a/scripts/inference_flux_lora.py
+++ b/scripts/inference_flux_lora.py
@@ -47,6 +47,7 @@ def inference(args):
             width=args.width,
             num_inference_steps=args.num_inference_steps,
             max_sequence_length=256,
+            generator=torch.Generator().manual_seed(args.seed)
         ).images[0]
         out.save(out_path)
 
@@ -63,5 +64,6 @@ if __name__ == "__main__":
     parser.add_argument("--height", type=int, default=768)
     parser.add_argument("--num_inference_steps", type=int, default=4)
     parser.add_argument("--guidance_scale", type=float, default=0.0)
+    parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
     inference(args)

--- a/shscripts/inference_cogVideox1.5_5b_i2v.sh
+++ b/shscripts/inference_cogVideox1.5_5b_i2v.sh
@@ -12,4 +12,5 @@ python scripts/inference_cogVideo_sat_refactor.py \
 --base $base    \
 --mode_type "i2v"   \
 --sampling_num_frames 22    \
---image_folder $image_folder
+--image_folder $image_folder \
+--seed 42

--- a/shscripts/inference_flux_lora.sh
+++ b/shscripts/inference_flux_lora.sh
@@ -9,4 +9,5 @@ python scripts/inference_flux_lora.py \
     --width 1360 \
     --height 768 \
     --num_inference_steps 50 \
-    --guidance_scale 3.5
+    --guidance_scale 3.5 \
+    --seed 42

--- a/videotuna/cogvideo_sat/arguments.py
+++ b/videotuna/cogvideo_sat/arguments.py
@@ -300,17 +300,18 @@ def getArgs():
                 )
         args.deepspeed_config = deepspeed_config
 
-    initialize_distributed(args)
-    args.seed = args.seed + mpu.get_data_parallel_rank()
-    set_random_seed(args.seed)
-
     args.load = parser.parse_args().load_transformer
     args.input_type = parser.parse_args().input_type
     args.input_file = parser.parse_args().input_file
     args.output_dir = parser.parse_args().output_dir
     args.image_folder = parser.parse_args().image_folder
+    args.seed = parser.parse_args().seed
     args.batch_size = 1
     args.bf16 = True
+
+    initialize_distributed(args)
+    args.seed = args.seed + mpu.get_data_parallel_rank()
+    set_random_seed(args.seed)
 
     del args.deepspeed_config
     args.model_config.first_stage_config.params.cp_size = 1


### PR DESCRIPTION
**Motivation**

Users can not easily use their random seed numbers to inference flux lora t2i and cogvideo i2v models.

**Changes**

- For flux lora t2i inference
  - `scripts/inference_flux_lora.py`: add seed argument support, add random seed control in inference
  - `shscripts/inference_flux_lora.sh`: support user-defined seed input

- For cogvideo i2v inference
  - `videotuna/cogvideo_sat/arguments.py`: add seed argument support
  - `scripts/inference_cogVideo_sat_refactor.py`: add random seed control in inference
  - `shscripts/inference_cogVideox1.5_5b_i2v.sh`: supports user-defined seed input