### PR TITLE
chore: migrate to modern Python Logger API

### DIFF
--- a/eval/vbench/third_party/tag2Text/med.py
+++ b/eval/vbench/third_party/tag2Text/med.py
@@ -572,7 +572,7 @@ class BertEncoder(nn.Module):
             if self.gradient_checkpointing and self.training:
 
                 if use_cache:
-                    logger.warn(
+                    logger.warning(
                         "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
                     )
                     use_cache = False

--- a/tools/data_process/caption/llava/model/multimodal_resampler/qformer.py
+++ b/tools/data_process/caption/llava/model/multimodal_resampler/qformer.py
@@ -527,7 +527,7 @@ class BertEncoder(nn.Module):
             if getattr(self.config, "gradient_checkpointing", False) and self.training:
 
                 if use_cache:
-                    logger.warn(
+                    logger.warning(
                         "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
                     )
                     use_cache = False

--- a/videotuna/models/cogvideo_sat/sgm/models/autoencoder.py
+++ b/videotuna/models/cogvideo_sat/sgm/models/autoencoder.py
@@ -161,7 +161,7 @@ class AutoencodingEngine(AbstractAutoencoder):
             )
             assert len(self.ae_optimizer_args) == len(self.trainable_ae_params)
         else:
-            self.ae_optimizer_args = [{}]  # makes type consitent
+            self.ae_optimizer_args = [{}]  # makes type consistent
 
         self.trainable_disc_params = trainable_disc_params
         if self.trainable_disc_params is not None:
@@ -171,11 +171,11 @@ class AutoencodingEngine(AbstractAutoencoder):
             )
             assert len(self.disc_optimizer_args) == len(self.trainable_disc_params)
         else:
-            self.disc_optimizer_args = [{}]  # makes type consitent
+            self.disc_optimizer_args = [{}]  # makes type consistent
 
         if ckpt_path is not None:
             assert ckpt_engine is None, "Can't set ckpt_engine and ckpt_path"
-            logpy.warn("Checkpoint path is deprecated, use `checkpoint_egnine` instead")
+            logpy.warning("Checkpoint path is deprecated, use `checkpoint_egnine` instead")
         self.apply_ckpt(default(ckpt_path, ckpt_engine))
         self.additional_decode_keys = set(default(additional_decode_keys, []))
 
@@ -368,7 +368,7 @@ class AutoencodingEngine(AbstractAutoencoder):
                         pattern_params.append(param)
                         num_params += param.numel()
                 if len(pattern_params) == 0:
-                    logpy.warn(f"Did not find parameters for pattern {pattern_}")
+                    logpy.warning(f"Did not find parameters for pattern {pattern_}")
                 params.extend(pattern_params)
             groups.append({"params": params, **args})
         return groups, num_params

--- a/videotuna/models/cogvideo_sat/vae_modules/autoencoder.py
+++ b/videotuna/models/cogvideo_sat/vae_modules/autoencoder.py
@@ -152,7 +152,7 @@ class AutoencodingEngine(AbstractAutoencoder):
             )
             assert len(self.ae_optimizer_args) == len(self.trainable_ae_params)
         else:
-            self.ae_optimizer_args = [{}]  # makes type consitent
+            self.ae_optimizer_args = [{}]  # makes type consistent
 
         self.trainable_disc_params = trainable_disc_params
         if self.trainable_disc_params is not None:
@@ -162,11 +162,11 @@ class AutoencodingEngine(AbstractAutoencoder):
             )
             assert len(self.disc_optimizer_args) == len(self.trainable_disc_params)
         else:
-            self.disc_optimizer_args = [{}]  # makes type consitent
+            self.disc_optimizer_args = [{}]  # makes type consistent
 
         if ckpt_path is not None:
             assert ckpt_engine is None, "Can't set ckpt_engine and ckpt_path"
-            logpy.warn("Checkpoint path is deprecated, use `checkpoint_egnine` instead")
+            logpy.warning("Checkpoint path is deprecated, use `checkpoint_egnine` instead")
         self.apply_ckpt(default(ckpt_path, ckpt_engine))
         self.additional_decode_keys = set(default(additional_decode_keys, []))
 
@@ -359,7 +359,7 @@ class AutoencodingEngine(AbstractAutoencoder):
                         pattern_params.append(param)
                         num_params += param.numel()
                 if len(pattern_params) == 0:
-                    logpy.warn(f"Did not find parameters for pattern {pattern_}")
+                    logpy.warning(f"Did not find parameters for pattern {pattern_}")
                 params.extend(pattern_params)
             groups.append({"params": params, **args})
         return groups, num_params

--- a/videotuna/models/hunyuan/hyvideo_i2v/vae/unet_causal_3d_blocks.py
+++ b/videotuna/models/hunyuan/hyvideo_i2v/vae/unet_causal_3d_blocks.py
@@ -445,7 +445,7 @@ def get_down_block3d(
 ):
     # If attn head dim is not defined, we default it to the number of heads
     if attention_head_dim is None:
-        logger.warn(
+        logger.warning(
             f"It is recommended to provide `attention_head_dim` when calling `get_down_block`. Defaulting `attention_head_dim` to {num_attention_heads}."
         )
         attention_head_dim = num_attention_heads
@@ -499,7 +499,7 @@ def get_up_block3d(
 ) -> nn.Module:
     # If attn head dim is not defined, we default it to the number of heads
     if attention_head_dim is None:
-        logger.warn(
+        logger.warning(
             f"It is recommended to provide `attention_head_dim` when calling `get_up_block`. Defaulting `attention_head_dim` to {num_attention_heads}."
         )
         attention_head_dim = num_attention_heads
@@ -569,7 +569,7 @@ class UNetMidBlockCausal3D(nn.Module):
         attentions = []
 
         if attention_head_dim is None:
-            logger.warn(
+            logger.warning(
                 f"It is not recommend to pass `attention_head_dim=None`. Defaulting `attention_head_dim` to `in_channels`: {in_channels}."
             )
             attention_head_dim = in_channels

--- a/videotuna/models/hunyuan/hyvideo_t2v/vae/unet_causal_3d_blocks.py
+++ b/videotuna/models/hunyuan/hyvideo_t2v/vae/unet_causal_3d_blocks.py
@@ -445,7 +445,7 @@ def get_down_block3d(
 ):
     # If attn head dim is not defined, we default it to the number of heads
     if attention_head_dim is None:
-        logger.warn(
+        logger.warning(
             f"It is recommended to provide `attention_head_dim` when calling `get_down_block`. Defaulting `attention_head_dim` to {num_attention_heads}."
         )
         attention_head_dim = num_attention_heads
@@ -499,7 +499,7 @@ def get_up_block3d(
 ) -> nn.Module:
     # If attn head dim is not defined, we default it to the number of heads
     if attention_head_dim is None:
-        logger.warn(
+        logger.warning(
             f"It is recommended to provide `attention_head_dim` when calling `get_up_block`. Defaulting `attention_head_dim` to {num_attention_heads}."
         )
         attention_head_dim = num_attention_heads
@@ -569,7 +569,7 @@ class UNetMidBlockCausal3D(nn.Module):
         attentions = []
 
         if attention_head_dim is None:
-            logger.warn(
+            logger.warning(
                 f"It is not recommend to pass `attention_head_dim=None`. Defaulting `attention_head_dim` to `in_channels`: {in_channels}."
             )
             attention_head_dim = in_channels


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```